### PR TITLE
Support exporting OpenTelemetry traces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,15 @@ cdr = "0.2.4"
 rust-lapper = "1.1.0"
 smoltcp = "0.9.1"
 etherparse = "0.13.0"
+tonic = "0.9.2"
+opentelemetry = "0.19.0"
+opentelemetry_api = { version = "0.19.0", features = ["metrics"] }
+opentelemetry_sdk = { version = "0.19.0", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.12.0", features = ["tonic", "metrics"] }
+opentelemetry-semantic-conventions = "0.11.0"
+libc = "0.2"
+gethostname = "0.4.3"
+mac_address = "1.1.5"
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod message;
 mod opts;
+mod otlp;
 mod rtps;
 mod state;
 mod ui;
@@ -21,6 +22,8 @@ use ui::Tui;
 
 fn main() -> Result<()> {
     let opts = Opts::parse();
+    let opts_clone = opts.clone();
+
     let (tx, rx) = flume::bounded(8192);
     let state = Arc::new(Mutex::new(State::default()));
 
@@ -41,7 +44,7 @@ fn main() -> Result<()> {
     let updater_handle = {
         let state = state.clone();
         thread::spawn(|| {
-            crate::updater::run_updater(rx, state);
+            crate::updater::run_updater(rx, state, opts_clone);
         })
     };
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,9 @@
+use etherparse::{Ethernet2Header, SingleVlanHeader};
+use pcap;
 use rustdds::{discovery::data_types::topic_data::DiscoveredWriterData, SequenceNumber, GUID};
+use smoltcp::wire::{Ipv4Packet, Ipv4Repr};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum RtpsEvent {
     Data(DataEvent),
     DataFrag(DataFragEvent),
@@ -18,7 +21,7 @@ impl From<DataEvent> for RtpsEvent {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DataEvent {
     pub writer_id: GUID,
     pub reader_id: GUID,
@@ -27,7 +30,7 @@ pub struct DataEvent {
     pub discovery_data: Option<DiscoveredWriterData>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DataFragEvent {
     pub writer_id: GUID,
     pub reader_id: GUID,
@@ -37,4 +40,18 @@ pub struct DataFragEvent {
     pub data_size: u32,
     pub fragment_size: u16,
     pub payload_size: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct PacketHeaders {
+    pub pcap_header: pcap::PacketHeader,
+    pub eth_header: Ethernet2Header,
+    pub vlan_header: Option<SingleVlanHeader>,
+    pub ipv4_header: Ipv4Repr,
+}
+
+#[derive(Debug, Clone)]
+pub struct RtpsMessage {
+    pub headers: PacketHeaders,
+    pub event: RtpsEvent,
 }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -11,4 +11,10 @@ pub struct Opts {
 
     #[clap(short = 'i', long)]
     pub interface: Option<String>,
+
+    #[clap(short = 'o', long)]
+    pub otlp_enable: bool,
+
+    #[clap(short = 'e', long, default_value = "http://localhost:4317")]
+    pub otlp_endpoint: Option<String>,
 }

--- a/src/otlp.rs
+++ b/src/otlp.rs
@@ -1,0 +1,143 @@
+use gethostname::gethostname;
+use mac_address::mac_address_by_name;
+
+use opentelemetry_api::global::shutdown_tracer_provider;
+use opentelemetry_api::trace::{Span, SpanBuilder, SpanKind, TraceError};
+use opentelemetry_api::{
+    metrics,
+    trace::{TraceContextExt, Tracer},
+    Context, Key, KeyValue,
+};
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::{runtime, trace as sdktrace, trace::Sampler, Resource};
+use opentelemetry_semantic_conventions as semcov;
+use std::alloc::System;
+use std::time::{Duration, SystemTime};
+
+use crate::message::{RtpsEvent, RtpsMessage};
+use crate::opts::Opts;
+use rustdds::structure::guid::{EntityId, EntityKind};
+
+pub struct TraceHandle {
+    tracer: sdktrace::Tracer,
+    mac_address: [u8; 6],
+}
+
+impl TraceHandle {
+    pub fn new(opts: Opts) -> Self {
+        let mac_address = match mac_address_by_name(&opts.interface.unwrap_or("eno2".to_string())) {
+            Ok(Some(ma)) => ma.bytes(),
+            Ok(None) => [0; 6],
+            Err(_) => [0; 6],
+        };
+
+        // `endpoint` should always be set from the opts.
+        let endpoint = opts
+            .otlp_endpoint
+            .unwrap_or_else(|| "http://localhost:4317".to_string());
+
+        let exporter = opentelemetry_otlp::new_exporter()
+            .tonic()
+            .with_endpoint(endpoint)
+            .with_timeout(Duration::from_secs(2));
+
+        let trace_config = sdktrace::config()
+            .with_sampler(Sampler::AlwaysOn)
+            .with_max_events_per_span(64)
+            .with_max_attributes_per_span(16)
+            .with_resource(Resource::new(vec![
+                KeyValue::new(semcov::resource::SERVICE_NAME, "dds.traffic"),
+                KeyValue::new(
+                    semcov::resource::HOST_NAME,
+                    gethostname().to_string_lossy().to_string(),
+                ),
+            ]));
+
+        let batch_config = sdktrace::BatchConfig::default()
+            .with_max_concurrent_exports(4)
+            .with_max_export_batch_size(512);
+
+        let tracer = opentelemetry_otlp::new_pipeline()
+            .tracing()
+            .with_exporter(exporter)
+            .with_trace_config(trace_config)
+            .with_batch_config(batch_config)
+            .install_batch(runtime::Tokio)
+            .unwrap();
+
+        TraceHandle {
+            mac_address,
+            tracer,
+        }
+    }
+
+    pub fn send_trace(&self, message: &RtpsMessage, topic_name: String) -> () {
+        let (headers, event) = (message.headers.clone(), message.event.clone());
+        let capture_time = headers.pcap_header.ts;
+        let ma: [u8; 6] = headers.eth_header.destination;
+
+        let (submsg_type, writer_id, sn, payload_size) = match event {
+            RtpsEvent::Data(event) => {
+                ("DATA", event.writer_id, event.writer_sn, event.payload_size)
+            }
+            RtpsEvent::DataFrag(event) => (
+                "DATA_FRAG",
+                event.writer_id,
+                event.writer_sn,
+                event.payload_size,
+            ),
+        };
+        let traffic_type = match writer_id.entity_id.entity_kind {
+            // TODO: add complete cases
+            EntityKind::WRITER_NO_KEY_USER_DEFINED => "USER_DEFINED",
+            _ => "BUILT_IN",
+        };
+
+        // Create attributes to be attached to the span.
+        let attrs = vec![
+            semcov::trace::EVENT_NAME.string("eno2"),
+            KeyValue::new("traffic_type", traffic_type.to_string()),
+            KeyValue::new("topic_name", topic_name.clone()),
+            KeyValue::new("writer_id", convert_to_colon_sep_hex(writer_id.to_bytes())),
+            KeyValue::new("sn", sn.0),
+            KeyValue::new("payload_size", payload_size as i64),
+        ];
+
+        // Create a span with the given attributes. The start time is set to captured time.
+        // The end time is set to captured time + payload size / 2.5Gbps.
+        let mut span = self.tracer.build(SpanBuilder {
+            name: submsg_type.into(),
+            span_kind: Some(SpanKind::Internal),
+            start_time: Some(convert_to_system_time(capture_time)),
+            attributes: Some(attrs.into_iter().collect()),
+            ..Default::default()
+        });
+        span.end_with_timestamp(
+            convert_to_system_time(capture_time)
+                + Duration::from_secs_f64(payload_size as f64 / (2.5 * 1e9)),
+        );
+
+        ()
+    }
+}
+
+impl Drop for TraceHandle {
+    fn drop(&mut self) {
+        shutdown_tracer_provider();
+    }
+}
+
+pub fn convert_to_system_time(capture_time: libc::timeval) -> SystemTime {
+    SystemTime::UNIX_EPOCH
+        + Duration::new(
+            capture_time.tv_sec as u64,
+            (capture_time.tv_usec * 1000) as u32,
+        )
+}
+
+pub fn convert_to_colon_sep_hex<const N: usize>(obj: [u8; N]) -> String {
+    obj.iter()
+        .map(|b| format!("{:02x}", b))
+        .collect::<Vec<_>>()
+        .join(":")
+}


### PR DESCRIPTION
ddshark will now have the command line options below. If the option `--otlp-enable` is set, then ddshark will export OpenTelemetry traces the the endpoint specified in `--otlp-endpoint`. The default endpoint is http://localhost:4317.

```bash
❯ ./target/release/ddshark --help
Usage: ddshark [OPTIONS]

Options:
      --refresh-rate <REFRESH_RATE>    [default: 4]
  -f, --file <FILE>                    
  -i, --interface <INTERFACE>          
  -o, --otlp-enable                    
  -e, --otlp-endpoint <OTLP_ENDPOINT>  [default: http://localhost:4317]
  -h, --help                           Print help
```

## Example OpenTelemetry traces
The output below is from `opentelemetry-collector-contrib`. I use ddshark to process a pcap file with two DATA_FRAG submessage.

```
❯ ./bin/otelcontribcol_linux_amd64 --config ./examples/demo/otel-collector-config.yaml
2023-05-30T00:13:59.538+0800	info	service/telemetry.go:104	Setting up own telemetry...
2023-05-30T00:13:59.539+0800	info	service/telemetry.go:127	Serving Prometheus metrics	{"address": ":8888", "level": "Basic"}
2023-05-30T00:13:59.539+0800	info	exporter@v0.78.3-0.20230525165144-87dd85a6c034/exporter.go:275	Development component. May change in the future.	{"kind": "exporter", "data_type": "traces", "name": "logging"}
2023-05-30T00:13:59.539+0800	info	exporter@v0.78.3-0.20230525165144-87dd85a6c034/exporter.go:275	Development component. May change in the future.	{"kind": "exporter", "data_type": "metrics", "name": "logging"}
2023-05-30T00:13:59.540+0800	info	service/service.go:131	Starting otelcontribcol...	{"Version": "0.78.0-dev", "NumCPU": 32}
2023-05-30T00:13:59.540+0800	info	extensions/extensions.go:30	Starting extensions...
2023-05-30T00:13:59.540+0800	warn	internal/warning.go:40	Using the 0.0.0.0 address exposes this server to every network interface, which may facilitate Denial of Service attacks	{"kind": "exporter", "data_type": "metrics", "name": "prometheus", "documentation": "https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md#safeguards-against-denial-of-service-attacks"}
2023-05-30T00:13:59.540+0800	warn	internal/warning.go:40	Using the 0.0.0.0 address exposes this server to every network interface, which may facilitate Denial of Service attacks	{"kind": "receiver", "name": "otlp", "data_type": "traces", "documentation": "https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md#safeguards-against-denial-of-service-attacks"}
2023-05-30T00:13:59.540+0800	info	otlpreceiver@v0.78.3-0.20230525165144-87dd85a6c034/otlp.go:83	Starting GRPC server	{"kind": "receiver", "name": "otlp", "data_type": "traces", "endpoint": "0.0.0.0:4317"}
2023-05-30T00:13:59.540+0800	info	service/service.go:148	Everything is ready. Begin running and processing data.
2023-05-30T00:14:08.960+0800	info	TracesExporter	{"kind": "exporter", "data_type": "traces", "name": "logging", "resource spans": 2, "spans": 2}
2023-05-30T00:14:08.960+0800	info	ResourceSpans #0
Resource SchemaURL: 
Resource attributes:
     -> host.name: Str(st9540808-i9-13900K)
     -> service.name: Str(dds.traffic)
ScopeSpans #0
ScopeSpans SchemaURL: 
InstrumentationScope opentelemetry-otlp 0.12.0
Span #0
    Trace ID       : 089865a8f6a78ba4439dca1be5e1f804
    Parent ID      : 
    ID             : af26f4637edec4e9
    Name           : DATA_FRAG
    Kind           : Internal
    Start time     : 2023-05-16 06:49:44.611157 +0000 UTC
    End time       : 2023-05-16 06:49:44.611162376 +0000 UTC
    Status code    : Unset
    Status message : 
Attributes:
     -> event.name: Str(eno2)
     -> topic_name: Str(<none>)
     -> writer_id: Str(01:10:59:06:e3:25:a3:7e:93:91:ab:42:00:00:37:03)
     -> traffic_type: Str(USER_DEFINED)
     -> payload_size: Int(13440)
     -> sn: Int(107)
ResourceSpans #1
Resource SchemaURL: 
Resource attributes:
     -> host.name: Str(st9540808-i9-13900K)
     -> service.name: Str(dds.traffic)
ScopeSpans #0
ScopeSpans SchemaURL: 
InstrumentationScope opentelemetry-otlp 0.12.0
Span #0
    Trace ID       : 4c5088952b038d52e87aa441f0db497f
    Parent ID      : 
    ID             : 0d562ec4e57317c7
    Name           : DATA_FRAG
    Kind           : Internal
    Start time     : 2023-05-16 06:49:44.611195 +0000 UTC
    End time       : 2023-05-16 06:49:44.611200376 +0000 UTC
    Status code    : Unset
    Status message : 
Attributes:
     -> payload_size: Int(13440)
     -> event.name: Str(eno2)
     -> topic_name: Str(<none>)
     -> writer_id: Str(01:10:59:06:e3:25:a3:7e:93:91:ab:42:00:00:37:03)
     -> traffic_type: Str(USER_DEFINED)
     -> sn: Int(107)
	{"kind": "exporter", "data_type": "traces", "name": "logging"}

```